### PR TITLE
Ensure CI pipelines' branch names don't overlap

### DIFF
--- a/lib/clear_skies/version.rb
+++ b/lib/clear_skies/version.rb
@@ -1,3 +1,3 @@
 module ClearSkies
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
This commit ensures Jenkins' pipeline project, that can all have a
master branch, don't report a "master" job name.  Instead, let's prefix
them with the pipeline name.